### PR TITLE
Fix FSF address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 		       Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+     51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -485,7 +485,7 @@ convey the exclusion of warranty; and each file should have at least the
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/demos/demo.py
+++ b/demos/demo.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 
 import base64

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 import base64
 from binascii import hexlify

--- a/demos/demo_sftp.py
+++ b/demos/demo_sftp.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 # based on code provided by raymond mosteller (thanks!)
 

--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 
 import base64

--- a/demos/forward.py
+++ b/demos/forward.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Sample script showing how to do local port forwarding over ssh.

--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 
 import socket

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Sample script showing how to do remote port forwarding over ssh.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 
 longdesc = '''

--- a/setup_helper.py
+++ b/setup_helper.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 # Note: Despite the copyright notice, this was submitted by John
 # Arbash Meinel.  Thanks John!

--- a/ssh/__init__.py
+++ b/ssh/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 I{'ssh'} 

--- a/ssh/agent.py
+++ b/ssh/agent.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 SSH Agent interface for Unix clients.

--- a/ssh/auth_handler.py
+++ b/ssh/auth_handler.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{AuthHandler}

--- a/ssh/ber.py
+++ b/ssh/ber.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 
 import util

--- a/ssh/buffered_pipe.py
+++ b/ssh/buffered_pipe.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Attempt to generalize the "feeder" part of a Channel: an object which can be

--- a/ssh/channel.py
+++ b/ssh/channel.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Abstraction for an SSH2 channel.

--- a/ssh/client.py
+++ b/ssh/client.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{SSHClient}.

--- a/ssh/common.py
+++ b/ssh/common.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Common constants and global variables.

--- a/ssh/compress.py
+++ b/ssh/compress.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Compression implementations for a Transport.

--- a/ssh/config.py
+++ b/ssh/config.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{SSHConfig}.

--- a/ssh/dsskey.py
+++ b/ssh/dsskey.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{DSSKey}

--- a/ssh/file.py
+++ b/ssh/file.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 BufferedFile.

--- a/ssh/hostkeys.py
+++ b/ssh/hostkeys.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{HostKeys}

--- a/ssh/kex_gex.py
+++ b/ssh/kex_gex.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Variant on L{KexGroup1 <ssh.kex_group1.KexGroup1>} where the prime "p" and

--- a/ssh/kex_group1.py
+++ b/ssh/kex_group1.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Standard SSH key exchange ("kex" if you wanna sound cool).  Diffie-Hellman of

--- a/ssh/logging22.py
+++ b/ssh/logging22.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Stub out logging on python < 2.3.

--- a/ssh/message.py
+++ b/ssh/message.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Implementation of an SSH2 "message".

--- a/ssh/packet.py
+++ b/ssh/packet.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Packetizer.

--- a/ssh/pipe.py
+++ b/ssh/pipe.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Abstraction of a one-way pipe where the read end can be used in select().

--- a/ssh/pkey.py
+++ b/ssh/pkey.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Common API for all public keys.

--- a/ssh/primes.py
+++ b/ssh/primes.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Utility functions for dealing with primes.

--- a/ssh/resource.py
+++ b/ssh/resource.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Resource manager.

--- a/ssh/rsakey.py
+++ b/ssh/rsakey.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{RSAKey}

--- a/ssh/server.py
+++ b/ssh/server.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{ServerInterface} is an interface to override for server support.

--- a/ssh/sftp.py
+++ b/ssh/sftp.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 import select
 import socket

--- a/ssh/sftp_attr.py
+++ b/ssh/sftp_attr.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 import stat
 import time

--- a/ssh/sftp_client.py
+++ b/ssh/sftp_client.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Client-mode SFTP support.

--- a/ssh/sftp_file.py
+++ b/ssh/sftp_file.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{SFTPFile}

--- a/ssh/sftp_handle.py
+++ b/ssh/sftp_handle.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Abstraction of an SFTP file handle (for server mode).

--- a/ssh/sftp_server.py
+++ b/ssh/sftp_server.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Server-mode SFTP support.

--- a/ssh/sftp_si.py
+++ b/ssh/sftp_si.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{SFTPServerInterface} is an interface to override for SFTP server support.

--- a/ssh/ssh_exception.py
+++ b/ssh/ssh_exception.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Exceptions defined by ssh.

--- a/ssh/transport.py
+++ b/ssh/transport.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 L{Transport} handles the core SSH2 protocol.

--- a/ssh/util.py
+++ b/ssh/util.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Useful functions used by the rest of ssh.

--- a/ssh/win_pageant.py
+++ b/ssh/win_pageant.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Functions for communicating with Pageant, the basic windows ssh agent program.

--- a/test.py
+++ b/test.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 do the unit tests!

--- a/tests/loop.py
+++ b/tests/loop.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 ...

--- a/tests/stub_sftp.py
+++ b/tests/stub_sftp.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 A stub SFTP server for loopback SFTP testing.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for authenticating over a Transport.

--- a/tests/test_buffered_pipe.py
+++ b/tests/test_buffered_pipe.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for BufferedPipe.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for SSHClient.

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for the BufferedFile abstraction.

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for HostKeys.

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for the key exchange protocols.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for ssh protocol message blocks.

--- a/tests/test_packetizer.py
+++ b/tests/test_packetizer.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for the ssh2 protocol in Transport.

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for public/private key objects.

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 some unit tests to make sure sftp works.

--- a/tests/test_sftp_big.py
+++ b/tests/test_sftp_big.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 some unit tests to make sure sftp works well with large files.

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for the ssh2 protocol in Transport.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
 
 """
 Some unit tests for utility functions.


### PR DESCRIPTION
I maintain Fabric in Fedora and as such I need to get ssh packaged and into the repos.

One of the requirements is reporting certain rpmlint issues upstream.

This patch applies to:

```
$ rpmlint -I incorrect-fsf-address
incorrect-fsf-address:
The Free Software Foundation address in this file seems to be outdated or
misspelled.  Ask upstream to update the address, or if this is a license file,
possibly the entire file with a new copy available from the FSF.
```

Which is reported as:

```
$ rpmlint python-ssh-1.7.13-1.fc16.noarch.rpm 
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/agent.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/channel.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/config.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_file.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/win_pageant.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/ssh_exception.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/client.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/buffered_pipe.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/compress.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/common.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/ber.py
python-ssh.noarch: E: incorrect-fsf-address /usr/share/doc/python-ssh-1.7.13/LICENSE
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_client.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/hostkeys.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/dsskey.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/pipe.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/file.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/transport.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/kex_group1.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/primes.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/util.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/message.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_server.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_handle.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/kex_gex.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/rsakey.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/logging22.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/__init__.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/auth_handler.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_si.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/server.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/sftp_attr.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/resource.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/packet.py
python-ssh.noarch: E: incorrect-fsf-address /usr/lib/python2.7/site-packages/ssh/pkey.py
1 packages and 0 specfiles checked; 36 errors, 0 warnings.
```
