### PR TITLE
Remove comparison between int and str

### DIFF
--- a/tests/loop.py
+++ b/tests/loop.py
@@ -62,12 +62,8 @@ class LoopSocket (object):
                 self.__cv.wait(self.__timeout)
             if len(self.__in_buffer) == 0:
                 raise socket.timeout
-            if n < self.__in_buffer:
-                out = self.__in_buffer[:n]
-                self.__in_buffer = self.__in_buffer[n:]
-            else:
-                out = self.__in_buffer
-                self.__in_buffer = ''
+            out = self.__in_buffer[:n]
+            self.__in_buffer = self.__in_buffer[n:]
             return out
         finally:
             self.__lock.release()


### PR DESCRIPTION
The code had been doing `
n < self.__in_buffer`
when it wants to be doing ```
n < len(self.__in_buffer)

```

In Python 2.x, this comparison (`int < str`) is always True. I found this while porting to Python 3 where it raises an error.

The code has been working without complaints because always taking the true branch of the conditional is actually fine. We don't need the false branch, so drop the check entirely.
```
