### PR TITLE
fix a racecondition within ssh-agent-forwarding code.

### DIFF
--- a/ssh/agent.py
+++ b/ssh/agent.py
@@ -186,10 +186,11 @@ class AgentClientProxy(object):
        the remote fake agent and the local agent
        -> Communication occurs ...
     """
-    def __init__(self, chanClient):
+    def __init__(self, chanRemote):
         self._conn = None
-        self.__chanC = chanClient
-        chanClient.request_forward_agent(self._forward_agent_handler)
+        self.__chanR = chanRemote
+        self.thread = AgentRemoteProxy(self, chanRemote)
+        self.thread.start()
 
     def __del__(self):
         self.close()
@@ -226,10 +227,6 @@ class AgentClientProxy(object):
             self.thread.join(1000)
         if self._conn is not None:
             self._conn.close()
-
-    def _forward_agent_handler(self, chanRemote):
-        self.thread = AgentRemoteProxy(self, chanRemote)
-        self.thread.start()
 
 class AgentServerProxy(AgentSSH):
     """
@@ -280,6 +277,15 @@ class AgentServerProxy(AgentSSH):
 
     def _get_filename(self):
         return self._file
+
+class AgentRequestHandler(object):
+    def __init__(self, chanClient):
+        self._conn = None
+        self.__chanC = chanClient
+        chanClient.request_forward_agent(self._forward_agent_handler)
+
+    def _forward_agent_handler(self, chanRemote):
+        AgentClientProxy(chanRemote)
 
 class Agent(AgentSSH):
     """


### PR DESCRIPTION
As long you use ssh-agent-forwarding more than once within a connection you get into a racecondition.
Multiple select's waiting for new data on your local ssh-agent socket. sshd will create a new channel for each connect to the fake-agent-socket on the remote server. On the py-ssh side all incoming ssh-agent packets going over  _ONE_ connection to the agent. E.g. open a py-ssh connection with agent-forwarding to a remote server. execute multiple times 'ssh-add -l' sometimes it will hang, because py-ssh received from channel 1 a ssh-auth-packet, forward it to local ssh-agent and channel 2's select see new data arrived and send it back over channel 2 instead of channel 1.
You can test it with fabric and ssh

run "fab -H host sleep"
while fabric sleeps connect with ssh and set env "export SSH_AUTH_SOCK=/tmp/ssh-XXXXXX/agent.<PID>" ; ssh-add -l ; ssh-add -l

``` python
from fabric.api import run, task, env
env.forward_agent = True
@task
def sleep():
    run("sleep 360")
```
