### PR TITLE
Adding support for the ProxyCommand feature

### DIFF
--- a/ssh/config.py
+++ b/ssh/config.py
@@ -55,7 +55,15 @@ class SSHConfig (object):
             line = line.rstrip('\n').lstrip()
             if (line == '') or (line[0] == '#'):
                 continue
-            if '=' in line:
+
+            # This is not actually true for some params, like
+            # ProxyCommand that should be split in the first space but
+            # it may contain an arbitrary string value with the `=' on
+            # it. So, let's treat it as a special case.
+            #
+            # Example that ilustrates this problem:
+            #   ssh -q -o StrictHostKeyChecking=no localhost nc %h 22
+            if '=' in line and not line.startswith('ProxyCommand'):
                 key, value = line.split('=', 1)
                 key = key.strip().lower()
             else:
@@ -167,7 +175,13 @@ class SSHConfig (object):
                     ('%l', fqdn),
                     ('%u', user),
                     ('%r', remoteuser)
-                ]
+                ],
+                'proxycommand' :
+                [
+                    ('%h', config['hostname']),
+                    ('%p', port),
+                    ('%r', remoteuser),
+                ],
                 }
         for k in config:
             if k in replacements:

--- a/ssh/packet.py
+++ b/ssh/packet.py
@@ -29,7 +29,7 @@ import time
 
 from ssh.common import *
 from ssh import util
-from ssh.ssh_exception import SSHException
+from ssh.ssh_exception import SSHException, BadProxyCommand
 from ssh.message import Message
 
 
@@ -254,6 +254,8 @@ class Packetizer (object):
                     pass
                 else:
                     n = -1
+            except BadProxyCommand:
+                raise
             except Exception:
                 # could be: (32, 'Broken pipe')
                 n = -1

--- a/ssh/proxy.py
+++ b/ssh/proxy.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2012  Yipit, Inc <coders@yipit.com>
+#
+# This file is part of ssh.
+#
+# 'ssh' is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# 'ssh' is distrubuted in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with 'ssh'; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA.
+
+import os
+import threading
+from shlex import split as shlsplit
+from subprocess import Popen, PIPE
+
+from ssh.ssh_exception import BadProxyCommand
+
+
+class CommandProxy(object):
+    """
+    A proxy based on the program informed in the ProxyCommand config.
+
+    This class implements a the interface needed by both L{Transport}
+    and L{Packetizer} classes. Using this class instead of a regular
+    socket makes it possible to talk with a popened command that will
+    proxy all the conversation between the client and a server hosted in
+    another machine.
+    """
+
+    def __init__(self, command_line):
+        """
+        Create a new CommandProxy instance. The instance created by this
+        class should be passed as argument to the L{Transport} class.
+
+        @param command_line: the command that should be executed and
+         used as the proxy.
+        @type command_line: str
+        """
+        self.cmd = shlsplit(command_line)
+        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+
+    def send(self, content):
+        """
+        Write the content received from the SSH client to the standard
+        input of the forked command.
+
+        @param content: string to be sent to the forked command
+        @type content: str
+        """
+        try:
+            self.process.stdin.write(content)
+        except IOError, exc:
+            # There was a problem with the child process. It is probably
+            # died and we can't proceed. The best option here is to
+            # raise an exception informing the user that the informed
+            # ProxyCommand is not working.
+            raise BadProxyCommand(' '.join(self.cmd), exc.strerror)
+        return len(content)
+
+    def recv(self, size):
+        """
+        Read from the standard output of the forked program
+
+        @param size: how many chars should be read
+        @type size: int
+
+        @return: the length of the readed content
+        @rtype: int
+        """
+        try:
+            return os.read(self.process.stdout.fileno(), size)
+        except IOError, exc:
+            raise BadProxyCommand(' '.join(self.cmd), exc.strerror)
+
+    def close(self):
+        self.process.terminate()
+
+    def settimeout(self, timeout):
+        pass
+

--- a/ssh/ssh_exception.py
+++ b/ssh/ssh_exception.py
@@ -113,3 +113,18 @@ class BadHostKeyException (SSHException):
         self.key = got_key
         self.expected_key = expected_key
 
+
+class BadProxyCommand (SSHException):
+    """
+    The "ProxyCommand" found in the .ssh/config file returned an error.
+
+    @ivar command: The command line that is generating this exception
+    @type command: str
+    @ivar error: The error captured from the proxy command output
+    @type error: str
+    """
+    def __init__(self, command, error):
+        SSHException.__init__(self,
+            '"ProxyCommand (%s)" returned non-zero exit status: %s' % (
+                command, error))
+        self.error = error

--- a/ssh/transport.py
+++ b/ssh/transport.py
@@ -44,7 +44,9 @@ from ssh.primes import ModulusPack
 from ssh.rsakey import RSAKey
 from ssh.server import ServerInterface
 from ssh.sftp_client import SFTPClient
-from ssh.ssh_exception import SSHException, BadAuthenticationType, ChannelException
+from ssh.ssh_exception import SSHException, BadAuthenticationType, \
+    ChannelException, BadProxyCommand
+
 
 from Crypto import Random
 from Crypto.Cipher import Blowfish, AES, DES3, ARC4
@@ -1657,6 +1659,8 @@ class Transport (threading.Thread):
                 timeout = 2
             try:
                 buf = self.packetizer.readline(timeout)
+            except BadProxyCommand:
+                raise
             except Exception, x:
                 raise SSHException('Error reading SSH protocol banner' + str(x))
             if buf[:4] == 'SSH-':


### PR DESCRIPTION
Now, instead of just ignoring the ProxyCommand var, the ssh library is able to retrieve
this configuration from the `~/.ssh/conf` file and use it to proxy the connection between
the client and the SSH server.

This commit introduces the ssh.proxy module that implements the interface required by
the `client.Transport` class. But instead of using sockets, this class writes and reads info
from a peopened program that actually talks with the ssh server.

Given the following ssh config entry:

```
host comum
User lincoln
hostname comum.org
IdentityFile ~/.ssh/id_rsa
ProxyCommand ssh -q -o StrictHostKeyChecking=no localhost nc %h 22
```

Here's a simple test case

``` python

import ssh
import sys

def test_client(host_name):
    conf = ssh.SSHConfig()
    conf.parse(open(os.path.expanduser('~/.ssh/config')))
    host = conf.lookup(host_name)
    client = ssh.SSHClient()
    client.load_system_host_keys()
    client.connect(
        host['hostname'], username=host['user'],
        key_filename=host['identityfile'],
        proxy_command=host.get('proxycommand')
    )
    stdin, stdout, stderr = client.exec_command('ls /home')
    print stdout.read()
    stdin, stdout, stderr = client.exec_command('ls /')
    print stdout.read()

if __name__ == '__main__':
    test_client(sys.argv[1])
```

Run it with the following comand:

``` shell
python example.py comum
```
